### PR TITLE
[Features] Add `Fit`/`Transform` and `Set_params`/`Get_params` Methods to QEK

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -771,7 +771,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_kernel = kernel.create_train_kernel_matrix(processed_dataset)\n",
+    "train_kernel = kernel.fit_transform(processed_dataset)\n",
     "y_tot = [data.target for data in processed_dataset]"
    ]
   },

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -158,9 +158,9 @@ class QuantumEvolutionKernel:
     def get_params(self, deep: bool = True) -> dict:
         """Retrieve the value of a single parameter by name.
 
-        Note: The `deep` parameter standardizes the `get_params` function to ensure 
-        compatibility with various machine learning libraries, such as scikit-learn. 
-        This allows the QuantumEvolutionKernel to seamlessly integrate into 
+        Note: The `deep` parameter standardizes the `get_params` function to ensure
+        compatibility with various machine learning libraries, such as scikit-learn.
+        This allows the QuantumEvolutionKernel to seamlessly integrate into
         scikit-learn workflows as a kernel.
 
         Args:
@@ -170,7 +170,6 @@ class QuantumEvolutionKernel:
             dict: A dictionary of parameters and their respective values.
         """
         return copy.deepcopy(self.params)
-        
 
 
 def count_occupation_from_bitstring(bitstring: str) -> int:

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -12,7 +12,22 @@ from qek.data.dataset import ProcessedData
 
 
 class QuantumEvolutionKernel:
+    """QuantumEvolutionKernel class.
+
+    Attributes:
+    - params (dict): Dictionary of training parameters.
+    - X (Sequence[ProcessedData]): Training data used for fitting the kernel
+    - kernel_matrix (np.ndarray): Kernel matrix. This is assigned in the `fit()` method
+
+
+    """
+
     def __init__(self, mu: float):
+        """Initialize the QuantumEvolutionKernel.
+
+        Args:
+            mu (float): Scaling factor for the Jensen-Shannon divergence
+        """
         self.params: dict[str, Any] = {"mu": mu}
         self.X: Sequence[ProcessedData]
         self.kernel_matrix: np.ndarray
@@ -146,7 +161,7 @@ class QuantumEvolutionKernel:
         return kernel_mat
 
     def set_params(self, **kwargs: dict[str, Any]) -> None:
-        """Set multiple parameters dynamically using setattr
+        """Set multiple parameters for the kernel.
 
         Args:
             **kwargs: Arbitrary keyword dictionary where keys are attribute names

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -13,7 +13,7 @@ from qek.data.dataset import ProcessedData
 class QuantumEvolutionKernel:
     def __init__(self, mu: float):
         self.params: dict[str, Any] = {"mu": mu}
-        self.train_dataset: Sequence[ProcessedData]
+        self.X: Sequence[ProcessedData]
         self.kernel_matrix: np.ndarray
 
     def __call__(
@@ -54,40 +54,43 @@ class QuantumEvolutionKernel:
         )  # Because the divergence is the square root of the distance
         return float(np.exp(-self.params["mu"] * js))
 
-    def fit(self, train_dataset: Sequence[ProcessedData]) -> None:
+    def fit(self, X: Sequence[ProcessedData], y: list = None) -> None:
         """Fit the kernel to the training dataset by storing the dataset.
 
         Args:
-            train_dataset (Sequence[ProcessedData]): The training dataset.
+            X (Sequence[ProcessedData]): The training dataset.
+            y: list: Target variable for the dataset sequence. defaults to None.
         """
-        self.train_dataset = train_dataset
-        self.kernel_matrix = self._create_kernel_matrix(self.train_dataset)
+        self.X = X
+        self.kernel_matrix = self._create_kernel_matrix(self.X)
 
-    def transform(self, test_dataset: Sequence[ProcessedData]) -> np.ndarray:
+    def transform(self, X_test: Sequence[ProcessedData], y_test: list = None) -> np.ndarray:
         """Transform the dataset into the kernel space with respect to the training dataset.
 
         Args:
-            test_dataset (Sequence[ProcessedData]): The dataset to transform.
+            X_test (Sequence[ProcessedData]): The dataset to transform.
+            y_test: list: Target variable for the dataset sequence. defaults to None.
 
         Returns:
             np.ndarray: Kernel matrix where each entry represents the similarity between
                         the given dataset and the training dataset.
         """
-        if self.train_dataset is None:
+        if self.X is None:
             raise ValueError("The kernel must be fit to a training dataset before transforming.")
 
-        return self._create_kernel_matrix(test_dataset, self.train_dataset)
+        return self._create_kernel_matrix(X_test, self.X)
 
-    def fit_transform(self, train_dataset: Sequence[ProcessedData]) -> np.ndarray:
+    def fit_transform(self, X: Sequence[ProcessedData], y: list = None) -> np.ndarray:
         """Fit the kernel to the training dataset and transform it.
 
         Args:
-            train_dataset (Sequence[ProcessedData]): The dataset to fit and transform.
+            X (Sequence[ProcessedData]): The dataset to fit and transform.
+            y: list: Target variable for the dataset sequence. defaults to None.
 
         Returns:
             np.ndarray: Kernel matrix for the training dataset.
         """
-        self.fit(train_dataset)
+        self.fit(X)
         return self.kernel_matrix
 
     def _create_kernel_matrix(

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 import collections
+import copy
 from collections.abc import Sequence
 
 import numpy as np
@@ -155,7 +156,12 @@ class QuantumEvolutionKernel:
             self.params[key] = value
 
     def get_params(self, deep: bool = True) -> dict:
-        """Retrieve the value of a single parameter by name
+        """Retrieve the value of a single parameter by name.
+
+        Note: The `deep` parameter standardizes the `get_params` function to ensure 
+        compatibility with various machine learning libraries, such as scikit-learn. 
+        This allows the QuantumEvolutionKernel to seamlessly integrate into 
+        scikit-learn workflows as a kernel.
 
         Args:
             deep (bool): Whether to return parameters of nested objects. Defaults to True.
@@ -163,7 +169,8 @@ class QuantumEvolutionKernel:
         Returns
             dict: A dictionary of parameters and their respective values.
         """
-        return self.params
+        return copy.deepcopy(self.params)
+        
 
 
 def count_occupation_from_bitstring(bitstring: str) -> int:

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -102,6 +102,9 @@ class QuantumEvolutionKernel:
         - An N x M kernel matrix between two datasets, where `dataset1` is the test dataset
         and `dataset2` is the training dataset (if both are provided).
 
+        The resulting matrix can be used as a similarity metric for machine learning algorithms,
+        particularly when evaluating the performance on the test dataset using a trained model.
+
         Args:
             dataset1 (Sequence[ProcessedData]): A list of ProcessedData objects representing
                 the first dataset (training or testing).
@@ -110,6 +113,8 @@ class QuantumEvolutionKernel:
 
         Returns:
             np.ndarray: A kernel matrix:
+            where the entry at row i and column j represents the similarity between the graph
+            in position i of the test dataset and the graph in position j of the training set.
                 - Symmetric N x N matrix if only `dataset1` is provided.
                 - N x M matrix if both `dataset1` and `dataset2` are provided.
         """

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -156,15 +156,11 @@ class QuantumEvolutionKernel:
             self.params[key] = value
 
     def get_params(self, deep: bool = True) -> dict:
-        """Retrieve the value of a single parameter by name.
+        """Retrieve the value of all parameters.
 
-        Note: The `deep` parameter standardizes the `get_params` function to ensure
-        compatibility with various machine learning libraries, such as scikit-learn.
-        This allows the QuantumEvolutionKernel to seamlessly integrate into
-        scikit-learn workflows as a kernel.
-
-        Args:
-            deep (bool): Whether to return parameters of nested objects. Defaults to True.
+         Args:
+            deep (bool): Ignored. Added for compatibility with various machine learning libraries,
+                such as scikit-learn.
 
         Returns
             dict: A dictionary of parameters and their respective values.

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 import collections
 from collections.abc import Sequence
 
@@ -11,7 +12,7 @@ from qek.data.dataset import ProcessedData
 
 class QuantumEvolutionKernel:
     def __init__(self, mu: float):
-        self.mu = mu
+        self.params: dict[str, Any] = {"mu": mu}
         self.train_dataset: Sequence[ProcessedData]
         self.kernel_matrix: np.ndarray
 
@@ -51,7 +52,7 @@ class QuantumEvolutionKernel:
         js = (
             jensenshannon(p=dist_graph_1, q=dist_graph_2) ** 2
         )  # Because the divergence is the square root of the distance
-        return float(np.exp(-self.mu * js))
+        return float(np.exp(-self.params["mu"] * js))
 
     def fit(self, train_dataset: Sequence[ProcessedData]) -> None:
         """Fit the kernel to the training dataset by storing the dataset.
@@ -136,6 +137,27 @@ class QuantumEvolutionKernel:
                     kernel_mat[i][j] = self(dataset1[i], dataset2[j])
 
         return kernel_mat
+
+    def set_params(self, **kwargs: dict[str, Any]) -> None:
+        """Set multiple parameters dynamically using setattr
+
+        Args:
+            **kwargs: Arbitrary keyword dictionary where keys are attribute names
+            and values are their respective values
+        """
+        for key, value in kwargs.items():
+            self.params[key] = value
+
+    def get_params(self, deep: bool = True) -> dict:
+        """Retrieve the value of a single parameter by name
+
+        Args:
+            deep (bool): Whether to return parameters of nested objects. Defaults to True.
+
+        Returns
+            dict: A dictionary of parameters and their respective values.
+        """
+        return self.params
 
 
 def count_occupation_from_bitstring(bitstring: str) -> int:

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -52,8 +52,8 @@ class QuantumEvolutionKernel:
             jensenshannon(p=dist_graph_1, q=dist_graph_2) ** 2
         )  # Because the divergence is the square root of the distance
         return float(np.exp(-self.mu * js))
-    
-    def fit(self, train_dataset: Sequence[ProcessedData]):
+
+    def fit(self, train_dataset: Sequence[ProcessedData]) -> None:
         """Fit the kernel to the training dataset by storing the dataset.
 
         Args:
@@ -76,7 +76,7 @@ class QuantumEvolutionKernel:
             raise ValueError("The kernel must be fit to a training dataset before transforming.")
 
         return self._create_kernel_matrix(test_dataset, self.train_dataset)
-    
+
     def fit_transform(self, train_dataset: Sequence[ProcessedData]) -> np.ndarray:
         """Fit the kernel to the training dataset and transform it.
 
@@ -118,7 +118,7 @@ class QuantumEvolutionKernel:
             N = len(dataset1)
             kernel_mat = np.zeros((N, N))
             for i in range(N):
-                for j in range(i + 1, N): 
+                for j in range(i + 1, N):
                     kernel_mat[i, j] = self(dataset1[i], dataset1[j])
                     kernel_mat[j][i] = kernel_mat[i][j]
         else:


### PR DESCRIPTION
Resolves #22 and #21

We implement the fit/transform methods for using the kernel. This typically takes X, y arguments - which are inputs and target values used for the optimization. 

Along side, we also implement the set_params/get_params methods - which allow for a proper integration with grid search routines. 