### PR TITLE
[API] Rework the return of a compiler to avoid async and make `target` optional.

### DIFF
--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "To extract machine-learning features from our dataset, we will need to configure a feature extractor. This library provides several feature extractors to either make use of a physical quantum device (QPU), or a variety of emulators.\n",
     "\n",
-    "To configure a feature extractor, we will need to give it a _compiler_, whose task is to take a list of graphs, extract embeddings and compile these embeddings to _sequences of pulses_, the format that can be executed  by either a QPU or an emulator. For this tutorial, our dataset is composed of molecule graphs, so we will use the `MoleculeGraphCompiler`:"
+    "To configure a feature extractor, we will need to give it a _compiler_, whose task is to take a list of graphs, extract embeddings and compile these embeddings to _sequences of pulses_, the format that can be executed  by either a QPU or an emulator. For this tutorial, our dataset is composed of molecule graphs encoded with the PTC-FM conventions, so we will use the `PTCFMGraphCompiler`:"
    ]
   },
   {
@@ -65,14 +65,14 @@
    "source": [
     "import qek.data.graphs as qek_graphs\n",
     "\n",
-    "compiler = qek_graphs.MoleculeGraphCompiler()"
+    "compiler = qek_graphs.PTCFMCompiler()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This library provides other compilers from other formats of graphs."
+    "This library provides other compilers from other formats of graphs, including the `MoleculeGraphCompiler` and general-purpose graph compilers for pytorch_geometric or networkx graphs."
    ]
   },
   {
@@ -126,8 +126,8 @@
     "# You can increase this value to higher number of qubits, but this\n",
     "# notebook will take longer to execute and may run out of memory.\n",
     "max_qubits = 5\n",
-    "processed_dataset = await extractor.run(max_qubits=max_qubits) # Don't forget to `await`!\n",
-    "display(\"Extracted features from %s samples\"% (len(processed_dataset), ))"
+    "processed_dataset = extractor.run(max_qubits=max_qubits)\n",
+    "display(\"Extracted features from %s samples\"% (len(processed_dataset.states), ))"
    ]
   },
   {
@@ -159,8 +159,6 @@
     "HAVE_PASQAL_ACCOUNT = False # If you have a PASQAL Cloud account, fill in the details and set this to `True`.\n",
     "\n",
     "if HAVE_PASQAL_ACCOUNT:\n",
-    "    processed_dataset = []\n",
-    "\n",
     "    # Use the QPU Extractor.\n",
     "    extractor = qek_extractors.QPUExtractor(\n",
     "        # Once computing is complete, data will be saved in this file.\n",
@@ -179,12 +177,12 @@
     "    display(\"Compiled %s sequences\" % (len(compiled), ))\n",
     "\n",
     "    # Launch the execution.\n",
-    "    execution = extractor.run()\n",
-    "    display(\"Work enqueued with ids %s\" % (extractor.batch_ids, ))\n",
+    "    processed_dataset = extractor.run()\n",
+    "    display(\"Work enqueued with ids %s\" % (processed_dataset.batch_ids, ))\n",
     "\n",
     "    # ...and wait for the results.\n",
-    "    processed_dataset = await execution\n",
-    "    display(\"Extracted features from %s samples\"% (len(processed_dataset), ))"
+    "    await processed_dataset\n",
+    "    display(\"Extracted states from %s samples\"% (len(processed_dataset.states), ))"
    ]
   },
   {
@@ -221,7 +219,8 @@
    "outputs": [],
    "source": [
     "import qek.data.dataset as qek_dataset\n",
-    "processed_dataset = qek_dataset.load_dataset(file_path=\"ptcfm_processed_dataset.json\")\n",
+    "from qek.data.dataset import ProcessedData\n",
+    "processed_dataset: list[ProcessedData] = qek_dataset.load_dataset(file_path=\"ptcfm_processed_dataset.json\")\n",
     "print(f\"Size of the quantum compatible dataset = {len(processed_dataset)}\")"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
   "torch",
   "torch_geometric",
   "matplotlib",
-  "emu-mps",
+  "emu-mps~=1.2.0",
 ]
 
 [tool.hatch.metadata]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,64 +1,72 @@
-from os import path
 from typing import cast
 
 import pytest
-import tempfile
 import torch_geometric.data as pyg_data
 import torch_geometric.datasets as pyg_dataset
-import qek.data.dataset as qek_dataset
-from qek.data.extractors import QutipExtractor, EmuMPSExtractor
-from qek.data.graphs import MoleculeGraphCompiler
+from qek.data.extractors import QutipExtractor, EmuMPSExtractor, BaseExtracted
+from qek.data.graphs import PTCFMCompiler
 
 
 @pytest.mark.asyncio
-async def test_emulators() -> None:
+async def test_async_emulators() -> None:
     """
-    Test that emulators can execute without exploding.
+    Test that emulators can execute without exploding (both sync and async).
     """
     # Load dataset
     original_ptcfm_data = [
         cast(pyg_data.Data, d) for d in pyg_dataset.TUDataset(root="dataset", name="PTC_FM")
     ]
     MAX_NUMBER_OF_SAMPLES = 5
+    MAX_NUMBER_OF_QUBITS = 5
 
-    molecule_compiler = MoleculeGraphCompiler()
+    ptcfm_compiler = PTCFMCompiler()
 
-    # Test QutipExtractor
-    qutip_path = path.join(tempfile.gettempdir(), "test_qutip_extractor.json")
-    qutip_extractor = QutipExtractor(path=qutip_path, compiler=molecule_compiler)
-    qutip_extractor.add_graphs(original_ptcfm_data[0:MAX_NUMBER_OF_SAMPLES])
-    qutip_compiled = qutip_extractor.compile()
-    assert (
-        len(qutip_compiled) > 0
-    )  # We know that some (but not all) of these samples can be compiled.
-    assert len(qutip_compiled) <= MAX_NUMBER_OF_SAMPLES
+    all_qutip_results: dict[bool, BaseExtracted] = {}
+    all_emu_mps_results: dict[bool, BaseExtracted] = {}
+    for sync in [True, False]:
+        # Test QutipExtractor
+        qutip_extractor = QutipExtractor(compiler=ptcfm_compiler)
+        qutip_extractor.add_graphs(original_ptcfm_data[0:MAX_NUMBER_OF_SAMPLES])
+        qutip_compiled = qutip_extractor.compile()
+        assert (
+            len(qutip_compiled) > 0
+        )  # We know that some (but not all) of these samples can be compiled.
+        assert len(qutip_compiled) <= MAX_NUMBER_OF_SAMPLES
 
-    qutip_results = await qutip_extractor.run()
-    assert (
-        len(qutip_compiled) > 0
-    )  # We know that some (but not all) of these these samples can be executed.
-    assert len(qutip_results) <= len(qutip_compiled)
+        qutip_results = qutip_extractor.run(max_qubits=MAX_NUMBER_OF_QUBITS)
+        all_qutip_results[sync] = qutip_results
+        if not sync:
+            await qutip_results
+        assert (
+            len(qutip_compiled) > 0
+        )  # We know that some (but not all) of these these samples can be executed.
+        assert len(qutip_results.raw_data) <= len(qutip_compiled)
 
-    # We cannot easily compare instances of `ProcessedData`, so we'll just check that deserialization doesn't explode
-    # and that we obtain the expected number of items.
-    qutip_loaded = qek_dataset.load_dataset(qutip_path)
-    assert len(qutip_loaded) == len(qutip_results)
+        # Test EmuMPSExtractor
+        emu_mps_extractor = EmuMPSExtractor(compiler=ptcfm_compiler)
+        emu_mps_extractor.add_graphs(original_ptcfm_data[0:MAX_NUMBER_OF_SAMPLES])
+        emu_mps_compiled = emu_mps_extractor.compile()
+        assert len(emu_mps_compiled) > 0  # We know that these samples can be compiled.
+        assert len(emu_mps_compiled) <= MAX_NUMBER_OF_SAMPLES
 
-    # Test EmuMPSExtractor
-    emu_mps_path = path.join(tempfile.gettempdir(), "test_qutip_extractor.json")
-    emu_mps_extractor = EmuMPSExtractor(path=emu_mps_path, compiler=molecule_compiler)
-    emu_mps_extractor.add_graphs(original_ptcfm_data[0:MAX_NUMBER_OF_SAMPLES])
-    emu_mps_compiled = emu_mps_extractor.compile()
-    assert len(emu_mps_compiled) > 0  # We know that these samples can be compiled.
-    assert len(emu_mps_compiled) <= MAX_NUMBER_OF_SAMPLES
+        emu_mps_results = emu_mps_extractor.run(max_qubits=MAX_NUMBER_OF_QUBITS)
+        all_emu_mps_results[sync] = emu_mps_results
+        if not sync:
+            await emu_mps_results
+        assert (
+            len(emu_mps_results.raw_data) > 0
+        )  # We know that some (but not all) of these these samples can be executed.
+        assert len(emu_mps_results.raw_data) <= len(emu_mps_results.raw_data)
 
-    emu_mps_results = await emu_mps_extractor.run()
-    assert (
-        len(emu_mps_results) > 0
-    )  # We know that some (but not all) of these these samples can be executed.
-    assert len(emu_mps_results) <= len(emu_mps_results)
+        # Compare what we can, which isn't much.
+        assert emu_mps_results.targets == qutip_results.targets
 
-    # We cannot easily compare instances of `ProcessedData`, so we'll just check that deserialization doesn't explode
-    # and that we obtain the expected number of items.
-    emu_mps_loaded = qek_dataset.load_dataset(emu_mps_path)
-    assert len(emu_mps_loaded) == len(emu_mps_results)
+    assert all_qutip_results[True].targets == all_qutip_results[False].targets
+    assert len(all_qutip_results[True].processed_data) == len(
+        all_qutip_results[False].processed_data
+    )
+
+    assert all_emu_mps_results[True].targets == all_emu_mps_results[False].targets
+    assert len(all_emu_mps_results[True].processed_data) == len(
+        all_emu_mps_results[False].processed_data
+    )

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -10,8 +10,8 @@ from torch_geometric.data import Data
 
 from qek.data.graphs import (
     BaseGraph,
-    MoleculeGraph,
-    MoleculeGraphCompiler,
+    PTCFMCompiler,
+    PTCFMGraph,
     PygWithPosCompiler,
     NXGraphCompiler,
     NXWithPos,
@@ -27,7 +27,7 @@ def test_graph_init() -> None:
     # Check that `add_graph_coord` doesn't break with this dataset.
 
     for i, data in enumerate(original_ptcfm_data):
-        graph = MoleculeGraph(data=data, device=pulser.AnalogDevice, id=i)
+        graph = PTCFMGraph(data=data, device=pulser.AnalogDevice, id=i)
 
         # Make sure that the graph has been augmented with "pos".
         assert hasattr(graph.pyg, "pos")
@@ -44,7 +44,7 @@ def test_graph_init() -> None:
         assert nx.is_isomorphic(nx_graph, nx_reconstruct)
 
     # The first graph from the dataset is known to be embeddable.
-    graph = MoleculeGraph(data=original_ptcfm_data[0], device=pulser.AnalogDevice, id=9999)
+    graph = PTCFMGraph(data=original_ptcfm_data[0], device=pulser.AnalogDevice, id=9999)
     assert graph.is_disk_graph(pulser.AnalogDevice.min_atom_distance + 0.01)
 
 
@@ -265,7 +265,7 @@ def test_basic_compile() -> None:
     assert (ingested.pyg.pos == saved_pyg_pos_ingested.pyg.pos).all()
 
     # Testing MoleculeGraphCompiler
-    molecule_graph_compiler = MoleculeGraphCompiler()
+    molecule_graph_compiler = PTCFMCompiler()
     ingested = molecule_graph_compiler.ingest(
         graph=original_ptcfm_data[0], device=pulser.AnalogDevice, id=9
     )


### PR DESCRIPTION
We don't want our users to need to understand `async`/`await` until they need to,
so we rework the output of extractors to make them usable without `async`/`await`.
Only users who write code for servers or interactive applications will need to `await`.

Also, we make `target` optional, because we want to be able to use our kernel with
data that does not come from the training material!

Note: breaking API changes, we'll need to bump version.