### PR TITLE
[Feature] Kernel integration - resolves #59

### DIFF
--- a/examples/tutorial 1a - Using a Quantum Device to Extract Machine-Learning Features - low-level.ipynb
+++ b/examples/tutorial 1a - Using a Quantum Device to Extract Machine-Learning Features - low-level.ipynb
@@ -201,11 +201,11 @@
     "MAX_QUBITS = 5\n",
     "\n",
     "processed_dataset = []\n",
-    "executor = QutipBackend(device=pl.AnalogDevice)\n",
+    "backend = QutipBackend(device=pl.AnalogDevice)\n",
     "for graph, register, pulse in tqdm(compiled):\n",
     "    if len(register.qubits) > MAX_QUBITS:\n",
     "        continue\n",
-    "    states = await executor.run(register=register, pulse=pulse)\n",
+    "    states = await backend.run(register=register, pulse=pulse)\n",
     "    processed_dataset.append(ProcessedData.from_register(register=register, pulse=pulse, device=pl.AnalogDevice, state_dict=states, target=graph.target))"
    ]
   },
@@ -253,10 +253,10 @@
     "        # See the documentation of PASQAL Cloud for other ways to provide your password.\n",
     "\n",
     "    # Initialize the cloud client\n",
-    "    executor = RemoteQPUBackend(username=my_username, project_id=my_project_id, password=my_password)\n",
+    "    backend = RemoteQPUBackend(username=my_username, project_id=my_project_id, password=my_password)\n",
     "\n",
     "    # Fetch the specification of our QPU\n",
-    "    device = await executor.device()\n",
+    "    device = await backend.device()\n",
     "\n",
     "    # As previously, create the list of graphs and embed them.\n",
     "    graphs_to_compile = []\n",
@@ -280,7 +280,7 @@
     "    for graph, register, pulse in tqdm(compiled):\n",
     "\n",
     "        # Send the work to the QPU and await the result\n",
-    "        states = await executor.run(register=register, pulse=pulse)\n",
+    "        states = await backend.run(register=register, pulse=pulse)\n",
     "        processed_dataset.append(ProcessedData.from_register(register=register, pulse=pulse, device=device, state_dict=states, target=graph.target))"
    ]
   },

--- a/examples/tutorial 2 - Machine-Learning with the Quantum EvolutionKernel.ipynb
+++ b/examples/tutorial 2 - Machine-Learning with the Quantum EvolutionKernel.ipynb
@@ -147,7 +147,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from qek.kernel import QuantumEvolutionKernel as QEK\n",
+    "from qek.kernel import FastQEK as QEK\n",
     "\n",
     "# Initialize the Quantum Evolution Kernel with a parameter mu\n",
     "kernel = QEK(mu=0.5)"
@@ -281,7 +281,7 @@
    "source": [
     "from sklearn.svm import SVC\n",
     "\n",
-    "# Define a SVC model with QuantumEvolutionKernel\n",
+    "# Define a SVC model with FastQEK\n",
     "qek_kernel = QEK(mu=0.5)\n",
     "model = SVC(kernel=qek_kernel, random_state=42)"
    ]

--- a/qek/data/extractors.py
+++ b/qek/data/extractors.py
@@ -299,7 +299,7 @@ class BaseExtractor(abc.ABC, Generic[GraphType]):
         """
         Compile all pending graphs into Pulser sequences that the Quantum Device may execute.
 
-        Once this method have succeeded, the results are stored in `self.sequences`.
+        Once this method has succeeded, the results are stored in `self.sequences`.
         """
         if len(self.graphs) == 0:
             raise Exception("No graphs to compile, did you forget to call `import_graphs`?")

--- a/qek/kernel/__init__.py
+++ b/qek/kernel/__init__.py
@@ -2,6 +2,9 @@
 The Quantum Evolution Kernel itself, for use in a machine-learning pipeline.
 """
 
-from .kernel import QuantumEvolutionKernel
+from .kernel import FastQEK, IntegratedQEK
 
-__all__ = ["QuantumEvolutionKernel"]
+# Alias, for backwards compatibility.
+QuantumEvolutionKernel = FastQEK
+
+__all__ = ["QuantumEvolutionKernel", "FastQEK", "IntegratedQEK"]

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -4,7 +4,8 @@ The Quantum Evolution Kernel itself, for use in a machine-learning pipeline.
 
 from __future__ import annotations
 
-from typing import Any, Callable, cast
+import abc
+from typing import Any, Generic, TypeVar, cast
 import collections
 import copy
 from collections.abc import Sequence
@@ -16,11 +17,19 @@ from scipy.spatial.distance import jensenshannon
 from qek.data.processed_data import ProcessedData
 from qek.data.extractors import BaseExtractor, GraphType
 
-class QuantumEvolutionKernel:
-    """Implementation of the Quantum Evolution Kernel.
+KernelData = TypeVar("KernelData")
+
+
+class BaseKernel(abc.ABC, Generic[KernelData]):
+    """
+    Base class for implementations of the Quantum Evolution Kernel.
+
+    Unless youre implementing a new kernel, you should probably consider using one of
+    the subclasses:
+    - QuantumEvolutionKernel (lower-level API, optimized for local use);
+    - IntegratedQuantumEvolutionKernel (higher-level API, generally slower).
 
     Attributes:
-    - params (dict): Dictionary of training parameters, see below.
     - X (Sequence[ProcessedData]): Training data used for fitting the kernel.
     - kernel_matrix (np.ndarray): Kernel matrix. This is assigned in the `fit()` method
 
@@ -53,7 +62,8 @@ class QuantumEvolutionKernel:
             similarity (optional): If specified, a custom similarity metric to use. Otherwise,
                 use the Jensen-Shannon divergence.
         """
-        self.params: dict[str, Any] = {
+        self._params: dict[str, Any] = {
+            "size_max": size_max,
             "mu": mu,
             "size_max": size_max,
             "similarity": similarity,
@@ -61,10 +71,17 @@ class QuantumEvolutionKernel:
         self.X: Sequence[ProcessedData]
         self.kernel_matrix: np.ndarray
 
+    @abc.abstractmethod
+    def to_processed_data(self, X: Sequence[KernelData]) -> Sequence[ProcessedData]:
+        """
+        Convert the raw data into features.
+        """
+        raise NotImplementedError
+
     def __call__(
         self,
-        X1: Sequence[ProcessedData],
-        X2: Sequence[ProcessedData] | None = None,
+        X1: Sequence[KernelData],
+        X2: Sequence[KernelData] | None = None,
     ) -> NDArray[np.floating]:
         """Compute a kernel matrix from two sequences of processed data.
 
@@ -89,14 +106,21 @@ class QuantumEvolutionKernel:
             `scipy.spatial.distance`, and it is squared because scipy function
             `jensenshannon` outputs the distance instead of the divergence.
         """
+        # Convert as needed.
+        # This can be *very* slow, depending on the implementation of `to_processed_data`.
+        p1 = self.to_processed_data(X1)
+        p2 = None
+        if X2 is not None:
+            p2 = self.to_processed_data(X2)
+
         # If size is not specified, set it to the length of the largest bitstring.
-        size_max = self.params["size_max"]
+        size_max = self._params["size_max"]
         if size_max is None:
-            if X2 is None:
+            if p2 is None:
                 # No need to walk the same source twice.
-                sources = [X1]
+                sources = [p1]
             else:
-                sources = [X1, X2]
+                sources = [p1, p2]
             for source in sources:
                 for data in source:
                     length = len(data._sequence.qubit_info)
@@ -106,17 +130,17 @@ class QuantumEvolutionKernel:
         # Note: At this stage, size_max could theoretically still be `None``, if both `X1` and `X2`
         # are empty. In such cases, `dist_excitation` will never be called, so we're ok.
 
-        mu = float(self.params["mu"])
-        feat_rows = [row.dist_excitation(size_max) for row in X1]
-        similarity = cast(
+        mu = float(self._params["mu"])
+        feat_rows = [row.dist_excitation(size_max) for row in p1]
+	similarity = cast(
             Callable[[NDArray[np.floating], NDArray[np.floating]], np.floating],
-            self.params["similarity"],
+            self._params["similarity"],
         )
 
         if similarity is None:
             similarity = self.default_similarity
 
-        if X2 is None:
+        if p2 is None:
             # Fast path:
             # - rows and columns are identical, so no need to compute a `feat_cols`;
             # - the matrix is symmetric, we only need to compute half of it.
@@ -124,7 +148,7 @@ class QuantumEvolutionKernel:
             # We could avoid computing kernel[i, i], as we know that it's always 1,
             # but we do not perform this specific optimization, as it is a useful
             # canary to detect some bugs.
-            kernel = np.zeros([len(X1), len(X1)])
+            kernel = np.zeros([len(p1), len(p1)])
             for i, dist_row in enumerate(feat_rows):
                 for j in range(i, len(feat_rows)):
                     dist_col = feat_rows[j]
@@ -136,8 +160,8 @@ class QuantumEvolutionKernel:
             # Slow path:
             # - we need to compute a `feat_columns`
             # - the matrix is generally not symmetric and diagonal entries are generally not 1.
-            kernel = np.zeros([len(X1), len(X2)])
-            feat_columns = [col.dist_excitation(size_max) for col in X2]
+            kernel = np.zeros([len(p1), len(p2)])
+            feat_columns = [col.dist_excitation(size_max) for col in p2]
             for i, dist_row in enumerate(feat_rows):
                 for j, dist_col in enumerate(feat_columns):
                     kernel[i, j] = similarity(dist_row, dist_col)
@@ -152,10 +176,10 @@ class QuantumEvolutionKernel:
         This is the default similarity, if no parameter `similarity` is provided.
         """
         js = jensenshannon(row, col) ** 2
-        mu = float(self.params["mu"])
+        mu = float(self._params["mu"])
         return np.exp(-mu * js)
 
-    def similarity(self, graph_1: ProcessedData, graph_2: ProcessedData) -> float:
+    def similarity(self, graph_1: KernelData, graph_2: KernelData) -> float:
         """Compute the similarity between two graphs using Jensen-Shannon
         divergence.
 
@@ -169,8 +193,8 @@ class QuantumEvolutionKernel:
         ProcessedData class from qek_os.data_io.dataset.
 
         Args:
-            graph_1 (ProcessedData): First graph.
-            graph_2 (ProcessedData): Second graph.
+            graph_1: First graph.
+            graph_2: Second graph.
 
         Returns:
             float: Similarity between the two graphs, scaled by a factor that
@@ -184,23 +208,23 @@ class QuantumEvolutionKernel:
         matrix = self([graph_1], [graph_2])
         return float(matrix[0, 0])
 
-    def fit(self, X: Sequence[ProcessedData], y: list | None = None) -> None:
+    def fit(self, X: Sequence[KernelData], y: list | None = None) -> None:
         """Fit the kernel to the training dataset by storing the dataset.
 
         Args:
-            X (Sequence[ProcessedData]): The training dataset.
+            X: The training dataset.
             y: list: Target variable for the dataset sequence.
                 This argument is ignored, provided only for compatibility
                 with machine-learning libraries.
         """
-        self.X = X
-        self.kernel_matrix = self.create_train_kernel_matrix(self.X)
+        self._X = X
+        self._kernel_matrix = self.create_train_kernel_matrix(self._X)
 
-    def transform(self, X_test: Sequence[ProcessedData], y_test: list | None = None) -> np.ndarray:
+    def transform(self, X_test: Sequence[KernelData], y_test: list | None = None) -> np.ndarray:
         """Transform the dataset into the kernel space with respect to the training dataset.
 
         Args:
-            X_test (Sequence[ProcessedData]): The dataset to transform.
+            X_test: The dataset to transform.
             y_test: list: Target variable for the dataset sequence.
                 This argument is ignored, provided only for compatibility
                 with machine-learning libraries.
@@ -208,16 +232,16 @@ class QuantumEvolutionKernel:
             np.ndarray: Kernel matrix where each entry represents the similarity between
                         the given dataset and the training dataset.
         """
-        if self.X is None:
+        if self._X is None:
             raise ValueError("The kernel must be fit to a training dataset before transforming.")
 
-        return self.create_test_kernel_matrix(X_test, self.X)
+        return self.create_test_kernel_matrix(X_test, self._X)
 
-    def fit_transform(self, X: Sequence[ProcessedData], y: list | None = None) -> np.ndarray:
+    def fit_transform(self, X: Sequence[KernelData], y: list | None = None) -> np.ndarray:
         """Fit the kernel to the training dataset and transform it.
 
         Args:
-            X (Sequence[ProcessedData]): The dataset to fit and transform.
+            X: The dataset to fit and transform.
             y: list: Target variable for the dataset sequence.
                 This argument is ignored, provided only for compatibility
                 with machine-learning libraries.
@@ -225,9 +249,9 @@ class QuantumEvolutionKernel:
             np.ndarray: Kernel matrix for the training dataset.
         """
         self.fit(X)
-        return self.kernel_matrix
+        return self._kernel_matrix
 
-    def create_train_kernel_matrix(self, train_dataset: Sequence[ProcessedData]) -> np.ndarray:
+    def create_train_kernel_matrix(self, train_dataset: Sequence[KernelData]) -> np.ndarray:
         """Compute a kernel matrix for a given training dataset.
 
         This method computes a symmetric N x N kernel matrix from the
@@ -235,8 +259,7 @@ class QuantumEvolutionKernel:
         dataset. The resulting matrix can be used as a similarity metric for
         machine learning algorithms.
         Args:
-            train_dataset (Sequence[ProcessedData]): A list of ProcessedData
-            objects to compute the kernel matrix from.
+            train_dataset: A list of objects to compute the kernel matrix from.
         Returns:
             np.ndarray: An N x N symmetric matrix where the entry at row i and
             column j represents the similarity between the graphs in positions
@@ -246,8 +269,8 @@ class QuantumEvolutionKernel:
 
     def create_test_kernel_matrix(
         self,
-        test_dataset: Sequence[ProcessedData],
-        train_dataset: Sequence[ProcessedData],
+        test_dataset: Sequence[KernelData],
+        train_dataset: Sequence[KernelData],
     ) -> np.ndarray:
         """
         Compute a kernel matrix for a given testing dataset and training
@@ -261,10 +284,8 @@ class QuantumEvolutionKernel:
         particularly when evaluating the performance on the test dataset using
         a trained model.
         Args:
-            test_dataset (Sequence[ProcessedData]): A list of ProcessedData
-            objects representing the testing dataset.
-            train_dataset (Sequence[ProcessedData]): A list of ProcessedData
-            objects representing the training set.
+            test_dataset: The testing dataset.
+            train_dataset: The training set.
         Returns:
             np.ndarray: An M x N matrix where the entry at row i and column j
             represents the similarity between the graph in position i of the
@@ -280,7 +301,7 @@ class QuantumEvolutionKernel:
             and values are their respective values
         """
         for key, value in kwargs.items():
-            self.params[key] = value
+            self._params[key] = value
 
     def get_params(self, deep: bool = True) -> dict[str, Any]:
         """Retrieve the value of all parameters.
@@ -293,10 +314,35 @@ class QuantumEvolutionKernel:
             dict: A dictionary of parameters and their respective values.
                 Note that this method always performs a copy of the dictionary.
         """
-        return copy.deepcopy(self.params)
+        return copy.deepcopy(self._params)
 
 
-class IntegratedQuantumEvolutionKernel(Generic[GraphType]):
+class QuantumEvolutionKernel(BaseKernel[ProcessedData]):
+    """QuantumEvolutionKernel class.
+
+    Attributes:
+    - X (Sequence[ProcessedData]): Training data used for fitting the kernel.
+    - kernel_matrix (np.ndarray): Kernel matrix. This is assigned in the `fit()` method
+
+    Training parameters:
+        mu (float): Scaling factor for the Jensen-Shannon divergence
+        size_max (int, optional): If specified, only consider the first `size_max`
+            qubits of bitstrings. Otherwise, consider all qubits. You may use this
+            to trade precision in favor of speed.
+
+    Note: This class does **not** accept raw data, but rather `ProcessedData`. See
+    class IntegratedQuantumEvolutionKernel for a subclass that provides a more powerful API,
+    at the expense of performance.
+    """
+
+    def to_processed_data(self, X: Sequence[ProcessedData]) -> Sequence[ProcessedData]:
+        """
+        Convert the raw data into features.
+        """
+        return X
+
+
+class IntegratedQuantumEvolutionKernel(BaseKernel[GraphType]):
     """
     A variant of the Quantum Evolution Kernel that supports fit/transform/fit_transform from raw data (graphs).
 
@@ -314,9 +360,18 @@ class IntegratedQuantumEvolutionKernel(Generic[GraphType]):
         size_max (int, optional): If specified, only consider the first `size_max`
             qubits of bitstrings. Otherwise, consider all qubits. You may use this
             to trade precision in favor of speed.
+        similarity (optional): If specified, a custom similarity metric to use. Otherwise,
+            use the Jensen-Shannon divergence.
     """
 
-    def __init__(self, mu: float, extractor: BaseExtractor[GraphType], size_max: int | None = None):
+    def __init__(self,
+		mu: float,
+		extractor: BaseExtractor[GraphType],
+		size_max: int | None = None,
+		similarity: (
+		    Callable[[NDArray[np.floating], NDArray[np.floating]], np.floating] | None
+		) = None,
+	):
         """
         Initialize an IntegratedQuantumEvolutionKernel
 
@@ -326,12 +381,13 @@ class IntegratedQuantumEvolutionKernel(Generic[GraphType]):
             size_max (int, optional): If specified, only consider the first `size_max`
                 qubits of bitstrings. Otherwise, consider all qubits. You may use this
                 to trade precision in favor of speed.
+            similarity (optional): If specified, a custom similarity metric to use. Otherwise,
+                use the Jensen-Shannon divergence.
         """
-        super().__init__()
-        self._qek = QuantumEvolutionKernel(mu=mu, size_max=size_max)
-        self._qek.params["extractor"] = extractor
+        super().__init__(mu=mu, size_max=size_max, similarity=similarity)
+        self._params["extractor"] = extractor
 
-    def extract(self, X: Sequence[GraphType]) -> Sequence[ProcessedData]:
+    def to_processed_data(self, X: Sequence[GraphType]) -> Sequence[ProcessedData]:
         """
         Convert the raw data into features.
 
@@ -345,211 +401,12 @@ class IntegratedQuantumEvolutionKernel(Generic[GraphType]):
         if isinstance(X[0], ProcessedData):
             return cast(Sequence[ProcessedData], X)
         graphs = [cast(GraphType, g) for g in X]
-        extractor: BaseExtractor[GraphType] = self._qek.params["extractor"]
+        extractor: BaseExtractor[GraphType] = self._params["extractor"]
         extractor.add_graphs(graphs)
         extracted = extractor.run()
         # Performance warning: this line can take hours to execute, if there's a long wait before
         # being allocated a QPU!
         return extracted.processed_data
-
-    def __call__(
-        self,
-        X1: Sequence[GraphType],
-        X2: Sequence[GraphType] | None = None,
-    ) -> NDArray[np.floating]:
-        """Compute a kernel matrix from two sequences of processed data.
-
-        This method computes a M x N kernel matrix from the Jensen-Shannon divergences
-        between all pairs of graphs in the two datasets. The resulting matrix can be used
-        as a similarity metric for machine learning algorithms.
-
-        If `X1` and `X2` are two sequences representing the processed data for a
-        single graph each, the resulting matrix can be used as a measure of similarity
-        between both graphs.
-
-        Performance warning:
-            This method can can be very slow if you use, for instance, a remote QPU, as the waitlines to
-            access a QPU can be very long. If you are using this in an interactive application or a server,
-            this will block the entire thread during the wait.
-
-        Args:
-            X1: processed data to be used as rows.
-            X2 (optional): processed data to be used as columns. If unspecified, use X1
-                as both rows and columns.
-        Returns:
-            np.ndarray: A len(X1) x len(X2) matrix where entry[i, j] represents the
-            similarity between rows[i] and columns[j], scaled by a factor that depends
-            on mu.
-        Notes:
-            The JSD is computed using the jensenshannon function from
-            `scipy.spatial.distance`, and it is squared because scipy function
-            `jensenshannon` outputs the distance instead of the divergence.
-        """
-        p1 = self.extract(X1)
-        if X2 is None:
-            p2 = None
-        else:
-            p2 = self.extract(X2)
-        return self._qek.__call__(p1, p2)
-
-    def similarity(self, graph_1: GraphType, graph_2: GraphType) -> float:
-        """Compute the similarity between two graphs using Jensen-Shannon
-        divergence.
-
-        This method computes the square of the Jensen-Shannon divergence (JSD)
-        between two probability distributions over bitstrings. The JSD is a
-        measure of the difference between two probability distributions, and it
-        can be used as a kernel for machine learning algorithms that require a
-        similarity function.
-
-        The input graphs are assumed to have been processed using the
-        ProcessedData class from qek_os.data_io.dataset
-
-        Performance warning:
-            This method can can be very slow if you use, for instance, a remote QPU, as the waitlines to
-            access a QPU can be very long. If you are using this in an interactive application or a server,
-            this will block the entire thread during the wait.
-
-        Args:
-            graph_1 (ProcessedData): First graph.
-            graph_2 (ProcessedData): Second graph.
-
-        Returns:
-            float: Similarity between the two graphs, scaled by a factor that
-            depends on mu.
-
-        Notes:
-            The JSD is computed using the jensenshannon function from
-            `scipy.spatial.distance`, and it is squared because scipy function
-            `jensenshannon` outputs the distance instead of the divergence.
-        """
-        matrix = self([graph_1], [graph_2])
-        return float(matrix[0, 0])
-
-    def fit(self, X: Sequence[GraphType], y: list | None = None) -> None:
-        """Fit the kernel to the training dataset by storing the dataset.
-
-        Performance warning:
-            This method can can be very slow if you use, for instance, a remote QPU, as the waitlines to
-            access a QPU can be very long. If you are using this in an interactive application or a server,
-            this will block the entire thread during the wait.
-
-
-        Args:
-            X: The training dataset.
-            y: list: Target variable for the dataset sequence.
-                This argument is ignored, provided only for compatibility
-                with machine-learning libraries.
-        """
-        seq = self.extract(X)
-        return self._qek.fit(seq, y)
-
-    def transform(self, X_test: Sequence[GraphType], y_test: list | None = None) -> np.ndarray:
-        """Transform the dataset into the kernel space with respect to the training dataset.
-
-        Performance warning:
-            This method can can be very slow if you use, for instance, a remote QPU, as the waitlines to
-            access a QPU can be very long. If you are using this in an interactive application or a server,
-            this will block the entire thread during the wait.
-
-        Args:
-            X_test): The dataset to transform.
-            y_test: list: Target variable for the dataset sequence.
-                This argument is ignored, provided only for compatibility
-                with machine-learning libraries.
-        Returns:
-            np.ndarray: Kernel matrix where each entry represents the similarity between
-                        the given dataset and the training dataset.
-        """
-        if self._qek.X is None:
-            raise ValueError("The kernel must be fit to a training dataset before transforming.")
-
-        seq = self.extract(X_test)
-        return self._qek.transform(seq, y_test)
-
-    def fit_transform(self, X: Sequence[GraphType], y: list | None = None) -> np.ndarray:
-        """Fit the kernel to the training dataset and transform it.
-
-        Performance warning:
-            This method can can be very slow if you use, for instance, a remote QPU, as the waitlines to
-            access a QPU can be very long. If you are using this in an interactive application or a server,
-            this will block the entire thread during the wait.
-
-        Args:
-            X: The dataset to fit and transform.
-            y: list: Target variable for the dataset sequence.
-                This argument is ignored, provided only for compatibility
-                with machine-learning libraries.
-        Returns:
-            np.ndarray: Kernel matrix for the training dataset.
-        """
-        seq = self.extract(X)
-        return self._qek.fit_transform(seq, y)
-
-    def set_params(self, **kwargs: dict[str, Any]) -> None:
-        """Set multiple parameters for the kernel.
-
-        Args:
-            **kwargs: Arbitrary keyword dictionary where keys are attribute names
-            and values are their respective values
-        """
-        self._qek.set_params(**kwargs)
-
-    def get_params(self, deep: bool = True) -> dict[str, Any]:
-        """Retrieve the value of all parameters.
-
-         Args:
-            deep (bool): Ignored for the time being. Added for compatibility with
-                various machine learning libraries, such as scikit-learn.
-
-        Returns
-            dict: A dictionary of parameters and their respective values.
-                Note that this method always performs a copy of the dictionary.
-        """
-        return self._qek.get_params(deep)
-
-    def create_train_kernel_matrix(self, train_dataset: Sequence[GraphType]) -> np.ndarray:
-        """Compute a kernel matrix for a given training dataset.
-
-        This method computes a symmetric N x N kernel matrix from the
-        Jensen-Shannon divergences between all pairs of graphs in the input
-        dataset. The resulting matrix can be used as a similarity metric for
-        machine learning algorithms.
-        Args:
-            train_dataset: A list of graphs to compute the kernel matrix from.
-
-        Returns:
-            np.ndarray: An N x N symmetric matrix where the entry at row i and
-            column j represents the similarity between the graphs in positions
-            i and j of the input dataset.
-        """
-        return self(train_dataset)
-
-    def create_test_kernel_matrix(
-        self,
-        test_dataset: Sequence[GraphType],
-        train_dataset: Sequence[GraphType],
-    ) -> np.ndarray:
-        """
-        Compute a kernel matrix for a given testing dataset and training
-        set.
-
-        This method computes an N x M kernel matrix from the Jensen-Shannon
-        divergences between all pairs of graphs in the input testing dataset
-        and the training dataset.
-        The resulting matrix can be used as a similarity metric for machine
-        learning algorithms,
-        particularly when evaluating the performance on the test dataset using
-        a trained model.
-        Args:
-            test_dataset: A list of graphs representing the testing dataset.
-            train_dataset: A list of graphs representing the training set.
-        Returns:
-            np.ndarray: An M x N matrix where the entry at row i and column j
-            represents the similarity between the graph in position i of the
-            test dataset and the graph in position j of the training set.
-        """
-        return self(test_dataset, train_dataset)
 
 
 def count_occupation_from_bitstring(bitstring: str) -> int:

--- a/qek/kernel/kernel.py
+++ b/qek/kernel/kernel.py
@@ -24,10 +24,10 @@ class BaseKernel(abc.ABC, Generic[KernelData]):
     """
     Base class for implementations of the Quantum Evolution Kernel.
 
-    Unless youre implementing a new kernel, you should probably consider using one of
-    the subclasses:
-    - QuantumEvolutionKernel (lower-level API, optimized for local use);
-    - IntegratedQuantumEvolutionKernel (higher-level API, generally slower).
+    Unless you are implementing a new kernel, you should probably consider
+    using one of the subclasses:
+    - QuantumEvolutionKernel (lower-level API, requires processed data, optimized);
+    - IntegratedQuantumEvolutionKernel (higher-level API, accepts graphs, slower).
 
     Attributes:
     - X (Sequence[ProcessedData]): Training data used for fitting the kernel.


### PR DESCRIPTION
Introduce a subclass of QuantumEvolutionKernel that can transparently call the QPU or Emulator. This should make tutorials easier to write, but in production, this is not recommended, as this is more fragile (e.g. in case of server connection error), can be extremely slow (e.g. if there is a long waitline for the QPU) and blocks the main thread.