### PR TITLE
[Doc] Update links to the Pasqal cloud doc

### DIFF
--- a/examples/tutorial 1 - Using a Quantum Device to Extract Machine-Learning Features.ipynb
+++ b/examples/tutorial 1 - Using a Quantum Device to Extract Machine-Learning Features.ipynb
@@ -167,7 +167,7 @@
     "## Creating and executing a feature extractor on a physical QPU\n",
     "\n",
     "Once you have checked that low qubit sequences provide the results you expect on an emulator, you will generally want to move to a QPU.\n",
-    "For this, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.cloud), which provides\n",
+    "For this, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.com/cloud), which provides\n",
     "you remote access to QPUs built and hosted by Pasqal. In this section, we'll see how to use the latter.\n",
     "\n",
     "If you don't have an account, just skip to the next section!"

--- a/examples/tutorial 1a - Using a Quantum Device to Extract Machine-Learning Features - low-level.ipynb
+++ b/examples/tutorial 1a - Using a Quantum Device to Extract Machine-Learning Features - low-level.ipynb
@@ -240,7 +240,7 @@
     "Once you have checked that the compiled graphs work on an emulator, you will probably want to move to a QPU. Execution on a QPU takes\n",
     "resources polynomial in the number of qubits, which hopefully means an almost exponential speedup for large number of qubits.\n",
     "\n",
-    "To experiment with a QPU, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.cloud), which provides you remote access to QPUs built and hosted by Pasqal. In this section, we'll see how to use the latter.\n",
+    "To experiment with a QPU, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.com/cloud), which provides you remote access to QPUs built and hosted by Pasqal. In this section, we'll see how to use the latter.\n",
     "\n",
     "If you don't have an account, just skip to the next section!"
    ]
@@ -303,7 +303,7 @@
    "source": [
     "There are other ways to use the SDK. For instance, you can enqueue a job and check later whether it has completed. Also, to work around the long waiting lines, Pasqal provides high-performance distributed and hardware-accelerated emulators, which you can access through the SDK.\n",
     "\n",
-    "For more details, [take a look at the documentation of the SDK](https://docs.pasqal.cloud/).\n"
+    "For more details, [take a look at the documentation of the SDK](https://docs.pasqal.com/cloud).\n"
    ]
   },
   {

--- a/examples/tutorial 1b - Training SVM QEK - low-level - generic dataset.ipynb
+++ b/examples/tutorial 1b - Training SVM QEK - low-level - generic dataset.ipynb
@@ -321,11 +321,11 @@
     "Once you have checked that the pulses work on an emulator, you will probably want to move to a QPU. Execution on a QPU takes\n",
     "resources polynomial in the number of qubits, which hopefully means an almost exponential speedup for large number of qubits.\n",
     "\n",
-    "To experiment with a QPU, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.cloud), which provides you remote access to QPUs built and hosted by Pasqal. In this section, we'll see how to use the latter.\n",
+    "To experiment with a QPU, you will need either physical access to a QPU, or an account with [PASQAL Cloud](https://docs.pasqal.com/cloud), which provides you remote access to QPUs built and hosted by Pasqal. In this section, we'll see how to use the latter.\n",
     "\n",
     "If you don't have an account, just skip to the next section!\n",
     "\n",
-    "> There are other ways to use the SDK. For instance, you can enqueue a job and check later whether it has completed. Also, to work around the long waiting lines, Pasqal provides high-performance distributed and hardware-accelerated emulators, which you can access through the SDK. For more details, [take a look at the documentation of the SDK](https://docs.pasqal.cloud/)."
+    "> There are other ways to use the SDK. For instance, you can enqueue a job and check later whether it has completed. Also, to work around the long waiting lines, Pasqal provides high-performance distributed and hardware-accelerated emulators, which you can access through the SDK. For more details, [take a look at the documentation of the SDK](https://docs.pasqal.com/cloud)."
    ]
   },
   {


### PR DESCRIPTION
The documentation for Pasqal Cloud services is now officially hosted as a `/cloud` sub-part in the new centralized documentation portal at [docs.pasqal.com](https://docs.pasqal.com). The docs.pasqal.cloud domain will soon be removed.

This PR changes all occurrences of `https://docs.pasqal.cloud` to `https://docs.pasqal.com/cloud`.

_One of the link refers specifically to the Cloud SDK, which will soon be integrated as a dedicated section in the cloud doc, I'll do another update when it's ready._