### PR TITLE
Fix KeyError in NXGraphCompiler and extending the class of embeddable graphs to unit disk graphs

### DIFF
--- a/qek/data/graphs.py
+++ b/qek/data/graphs.py
@@ -74,6 +74,32 @@ class BaseGraph:
         self.target = target
         self.id = id
 
+    def is_unit_disk_graph(self) -> bool:
+        """
+        Check if `self` is a unit disk graph.
+
+        Returns:
+            `True` if the graph is a unit disk graph.
+            `False` otherwise.
+        """
+
+        # Check the distances between all pairs of nodes.
+        pos = self.pyg.pos
+        assert pos is not None
+
+        non_connected_distances_um = [
+            np.linalg.norm(np.array(pos[u]) - np.array(pos[v]))
+            for u, v in nx.non_edges(self.nx_graph)
+        ]
+        connected_distances_um = [
+            np.linalg.norm(np.array(pos[u]) - np.array(pos[v])) for u, v in self.nx_graph.edges()
+        ]
+
+        if min(non_connected_distances_um) < max(connected_distances_um):
+            return False
+
+        return True
+
     def is_disk_graph(self, radius: float) -> bool:
         """
         A predicate to check if `self` is a disk graph with the specified

--- a/qek/data/graphs.py
+++ b/qek/data/graphs.py
@@ -67,7 +67,7 @@ class BaseGraph:
         # The graph in networkx format, undirected.
         self.nx_graph: nx.Graph = pyg_utils.to_networkx(
             data=data,
-            node_attrs=["x"],
+            node_attrs=["x"] if data.x is not None else None,
             edge_attrs=["edge_attr"] if data.edge_attr is not None else None,
             to_undirected=True,
         )

--- a/qek/data/graphs.py
+++ b/qek/data/graphs.py
@@ -83,6 +83,15 @@ class BaseGraph:
             `False` otherwise.
         """
 
+        if self.pyg.num_nodes == 0 or self.pyg.num_nodes is None:
+            logger.debug("graph %s doesn't have any nodes, it's not a disk graph", self.id, self.id)
+            return False
+
+        # Check if the graph is connected.
+        if len(self.nx_graph) == 0 or not nx.is_connected(self.nx_graph):
+            logger.debug("graph %s is not connected, it's not a disk graph", self.id)
+            return False
+
         # Check the distances between all pairs of nodes.
         pos = self.pyg.pos
         assert pos is not None
@@ -91,6 +100,11 @@ class BaseGraph:
             np.linalg.norm(np.array(pos[u]) - np.array(pos[v]))
             for u, v in nx.non_edges(self.nx_graph)
         ]
+
+        # Fully connected graphs are always unit disk graphs
+        if len(non_connected_distances_um) == 0:
+            return True
+
         connected_distances_um = [
             np.linalg.norm(np.array(pos[u]) - np.array(pos[v])) for u, v in self.nx_graph.edges()
         ]

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -50,8 +50,7 @@ def test_graph_init() -> None:
 
 
 def test_is_unit_disk_graph_false() -> None:
-    """Testing is_unit_disk_graph: these graphs are *not* unit disk graphs
-    """
+    """Testing is_unit_disk_graph: these graphs are *not* unit disk graphs"""
 
     # The empty graph is not a disk graph.
     graph_empty = BaseGraph(
@@ -117,6 +116,7 @@ def test_is_unit_disk_graph_false() -> None:
     )
     assert not graph_non_udg.is_unit_disk_graph()
 
+
 def test_is_unit_disk_graph_true() -> None:
     """
     Testing is_disk_graph: these graphs are unit disk graphs
@@ -167,6 +167,7 @@ def test_is_unit_disk_graph_true() -> None:
         device=pulser.AnalogDevice,
     )
     assert graph_connected_close.is_unit_disk_graph()
+
 
 def test_is_disk_graph_false() -> None:
     """
@@ -388,3 +389,15 @@ def test_basic_compile() -> None:
     assert isinstance(sample, Data)
     ingested = molecule_graph_compiler.ingest(graph=sample, device=pulser.AnalogDevice, id=9)
     assert ingested.id == 9
+
+
+def test_NXGraphCompiler_ingest_from_networkx() -> None:
+    """Testing the NXGraphCompiler ingest starting from a networkx graph"""
+
+    nx_graph = nx.Graph()
+    nx_graph.add_edges_from([(1, 2), (2, 3)])
+    nx.set_node_attributes(nx_graph, {1: [0, 0], 2: [5.02, 0], 3: [11.02, 0]}, "pos")
+    nx_with_pos = NXWithPos(nx_graph, positions=nx.get_node_attributes(nx_graph, "pos"), target=0)
+    compiler = NXGraphCompiler()
+    graph = compiler.ingest(nx_with_pos, device=pulser.AnalogDevice, id=0)
+    assert graph.is_unit_disk_graph()

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -49,6 +49,125 @@ def test_graph_init() -> None:
     assert graph.is_disk_graph(pulser.AnalogDevice.min_atom_distance + 0.01)
 
 
+def test_is_unit_disk_graph_false() -> None:
+    """Testing is_unit_disk_graph: these graphs are *not* unit disk graphs
+    """
+
+    # The empty graph is not a disk graph.
+    graph_empty = BaseGraph(
+        id=0,
+        data=Data(
+            x=torch.tensor([], dtype=torch.float),
+            edge_index=torch.tensor([], dtype=torch.int),
+            pos=torch.tensor([], dtype=torch.float),
+            y=1,
+        ),
+        device=pulser.AnalogDevice,
+    )
+    assert not graph_empty.is_unit_disk_graph()
+
+    # This graph has three nodes, each pair of nodes is closer than
+    # the diameter, but it's not a disk graph because one of the nodes
+    # is not connected.
+    graph_disconnected_close = BaseGraph(
+        id=0,
+        data=Data(
+            x=torch.tensor([[0], [1], [2]], dtype=torch.float),
+            edge_index=torch.tensor(
+                [
+                    [0, 1],  # edge 0 -> 1
+                    [1, 0],  # edge 1 -> 0
+                ],
+                dtype=torch.int,
+            ),
+            pos=torch.tensor([[0], [1], [2]], dtype=torch.float),
+            y=1,
+        ),
+        device=pulser.AnalogDevice,
+    )
+    assert not graph_disconnected_close.is_unit_disk_graph()
+
+    # This graph has three nodes, two nodes are connected, but it's
+    # not a disk graph because the non connected node distance is shorter than the connected edges
+    graph_non_udg = BaseGraph(
+        id=0,
+        data=Data(
+            x=torch.tensor([[0], [1], [2]], dtype=torch.float),
+            edge_index=torch.tensor(
+                [
+                    [
+                        0,
+                        1,  # edge 0 -> 1
+                        1,
+                        2,  # edge 1 -> 2
+                    ],
+                    [
+                        1,
+                        0,  # edge 1 -> 0
+                        2,
+                        1,  # edge 2 -> 1
+                    ],
+                ],
+                dtype=torch.int,
+            ),
+            pos=torch.tensor([[0, 0], [0, 1], [0.1, 0]], dtype=torch.float),
+            y=1,
+        ),
+        device=pulser.AnalogDevice,
+    )
+    assert not graph_non_udg.is_unit_disk_graph()
+
+def test_is_unit_disk_graph_true() -> None:
+    """
+    Testing is_disk_graph: these graphs are unit disk graphs
+    """
+    # Single node
+    graph_single_node = BaseGraph(
+        id=0,
+        data=Data(
+            x=torch.tensor([0], dtype=torch.float),
+            edge_index=torch.tensor([]),
+            pos=torch.tensor([], dtype=torch.float),
+            y=1,
+        ),
+        device=pulser.AnalogDevice,
+    )
+    assert graph_single_node.is_unit_disk_graph()
+
+    # A complete graph with three nodes, each of the edges
+    # is shorter than the disk's diameter.
+    graph_connected_close = BaseGraph(
+        id=0,
+        data=Data(
+            x=torch.tensor([[0], [1], [2]], dtype=torch.float),
+            edge_index=torch.tensor(
+                [
+                    [
+                        0,
+                        1,  # edge 0 -> 1
+                        1,
+                        2,  # edge 1 -> 2
+                        0,
+                        2,  # edge 0 -> 2
+                    ],
+                    [
+                        1,
+                        0,  # edge 1 -> 0
+                        2,
+                        1,  # edge 2 -> 1
+                        2,
+                        0,  # edge 2 -> 0
+                    ],
+                ],
+                dtype=torch.int,
+            ),
+            pos=torch.tensor([[0], [1], [2]], dtype=torch.float),
+            y=1,
+        ),
+        device=pulser.AnalogDevice,
+    )
+    assert graph_connected_close.is_unit_disk_graph()
+
 def test_is_disk_graph_false() -> None:
     """
     Testing is_disk_graph: these graphs are *not* disk graphs


### PR DESCRIPTION
This pull request introduces the following improvements and bug fixes:

1. **Fix for KeyError in NXGraphCompiler:** an issue was identified where a `KeyError: "x"` occurred when a NetworkX graph was passed to the NXGraphCompiler. This error was caused by a missing check for the existence of the "x" attribute in the graph. The fix involves adding a validation step to ensure that the "x" attribute is present before it is accessed.

2. **New Method: is_unit_disk_graph:** a new method, `is_unit_disk_graph()`, has been added to the BaseGraph class. This method provides a straightforward way to check whether a graph is a unit disk graph, rather than a disk graph.

3. **Update to is_embeddable Method:** the `is_embeddable() `method has been modified to use `is_unit_disk_graph()` rather than the previous `is_disk_graph()` method. The change was made because the old implementation, which used a radius of min_atom_distance + epsilon, while correct in theory, unnecessarily limited the class of embeddable graphs. By restricting embeddability to only those unit disk graphs with edges between `min_atom_edge_distance` and `min_atom_edge_distance + epsilon`, the method was excluding graphs that should have been considered embeddable. The new approach broadens the criteria allowing to embed unit disk graphs.